### PR TITLE
added thumbnail option

### DIFF
--- a/lightbox.rb
+++ b/lightbox.rb
@@ -12,12 +12,18 @@ module Jekyll
       # The path to our image
       @path = text.split(/\s+/)[0].strip
 
+      # The path to our thumb
+      @thumb = text.split(/\s+/)[0].strip
+
+
       # Defaults
       @title = ''
       @alt = ''
       @img_style = ''
       @class = ''
       @data = ''
+      @thumb =''
+
 
       # Parse Options
       if text =~ /--title="([^"]*)"/i
@@ -35,6 +41,10 @@ module Jekyll
       if text =~ /--data="([^"]*)"/i
         @data = text.match(/--data="([^"]*)"/i)[1]
       end
+      if text =~ /--thumb="([^"]*)"/i
+        @thumb = text.match(/--thumb="([^"]*)"/i)[1]
+      end
+
 
     end
 
@@ -42,7 +52,7 @@ module Jekyll
       url = context.registers[:page]["url"]
       relative = "../" * (url.split("/").length-1)
       src = File.join(relative, @path == nil ? '' : @path);
-      %{<a href="#{src}" data-lightbox="#{@data}" data-title="#{@title}"><img src="#{src}" alt="#{@alt || @title}" class="#{@class}" style="#{@img_style}"/></a>}
+      %{<a href="#{src}" data-lightbox="#{@data}" data-title="#{@title}"><img src="#{@thumb}" alt="#{@alt || @title}" class="#{@class}" style="#{@img_style}"/></a>}
     end
   end
 end


### PR DESCRIPTION
lightbox2 source has thumbs

```
      <h3 style="clear: both;">Four image set</h3>
      <div class="image-row">
        <div class="image-set">
          <a class="example-image-link" href="images/image-3.jpg" data-lightbox="example-set" data-title="Click the right half of the image to move forward."><img class="example-image" src="images/thumb-3.jpg" alt="Golden Gate Bridge with San Francisco in distance"></a>
          <a class="example-image-link" href="images/image-4.jpg" data-lightbox="example-set" data-title="Or press the right arrow on your keyboard."><img class="example-image" src="images/thumb-4.jpg" alt="Forest with mountains behind"></a>
          <a class="example-image-link" href="images/image-5.jpg" data-lightbox="example-set" data-title="The next image in the set is preloaded as you&apos;re viewing."><img class="example-image" src="images/thumb-5.jpg" alt="Bicyclist looking out over hill at ocean"></a>
          <a class="example-image-link" href="images/image-6.jpg" data-lightbox="example-set" data-title="Click anywhere outside the image or the X to the right to close."><img class="example-image" src="images/thumb-6.jpg" alt="Small lighthouse at bottom with ocean behind"></a>
        </div>
      </div>
```
